### PR TITLE
fix: identificar número da div do assunto

### DIFF
--- a/src/modules/FiltroAssuntoPace/FiltroAssuntoPaceUseCase.ts
+++ b/src/modules/FiltroAssuntoPace/FiltroAssuntoPaceUseCase.ts
@@ -13,6 +13,7 @@ import { getPastaProcessoJudicialUseCase } from '../GetPasta';
 import { getCapaUseCase } from '../GetCapa';
 import { getXPathText } from './helps/GetTextoPorXPATH';
 import { getUsuarioUseCase } from '../GetUsuario';
+import { identificarDivXpathAssunto } from './helps/identificarDivXpathAssunto';
 
 interface audienciasTipadas {
   processo: string;
@@ -76,10 +77,9 @@ export class FiltroAssuntoPaceUseCase {
 
           const capa: string = await getCapaUseCase.execute(NUP, cookie);
           const capaFormatada = new JSDOM(capa);
-          const xpathAssunto = '/html/body/div/div[7]/table/tbody/tr[2]/td[1]';
+          const divNumberAssunto = identificarDivXpathAssunto(capaFormatada);
+          const xpathAssunto = `/html/body/div/div[${divNumberAssunto}]/table/tbody/tr[2]/td[1]`;
           const assunto = await getXPathText(capaFormatada, xpathAssunto);
-          console.log('---ASSUNTO');
-          console.log(assunto);
 
           const objectAudienciaTipada = {
             processo: audiencia,

--- a/src/modules/FiltroAssuntoPace/helps/identificarDivXpathAssunto.ts
+++ b/src/modules/FiltroAssuntoPace/helps/identificarDivXpathAssunto.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getXPathText } from './GetTextoPorXPATH';
+
+export const identificarDivXpathAssunto = (capaFormatada: any): number => {
+  let linhaAtual = 1;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const xpathInicial = `/html/body/div/div[${linhaAtual}]/div/b`;
+
+    const assunto = getXPathText(capaFormatada, xpathInicial);
+
+    if (assunto.trim() === 'Assuntos') {
+      console.log('Linha correta: ', xpathInicial);
+      return linhaAtual;
+    }
+
+    linhaAtual++;
+  }
+};


### PR DESCRIPTION
* Erro: Visão pegando o valor errado do xpath do assunto, pois há processos com mais divs antes do assunto.

* Solução: Criar uma função para identificar o número da div antes de buscar o assunto de fato.